### PR TITLE
Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.5)
 
+#For cmake version 3.0 and higher. See "cmake --help-policy CMP0026"
+if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0)
+    cmake_policy(SET CMP0026 OLD)
+endif()
+
+#For cmake version 3.0 and higher. See "cmake --help-policy CMP0037"
+if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0)
+    cmake_policy(SET CMP0037 OLD)
+endif()
+
 set(PROJECT_NAME_STR booredis)
 project(${PROJECT_NAME_STR})
 
@@ -77,6 +87,7 @@ CONFIGURE_FILE(
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
   IMMEDIATE @ONLY)
 
+ # TODO: Deprecate use of "LOCATION" (CMP0026)
 GET_TARGET_PROPERTY(LIB_OUT_NAME ${PROJECT_LIB} LOCATION)
 GET_FILENAME_COMPONENT(LIB_OUT_NAME ${LIB_OUT_NAME} NAME)
 

--- a/src/booredisasync.h
+++ b/src/booredisasync.h
@@ -8,6 +8,7 @@
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/scoped_ptr.hpp>
 
 
 class BooRedisAsync


### PR DESCRIPTION
Commit be78d20 - fix cmake policies CMP0026 and CMP0037 by set its behavior to OLD(before CMake 3.0). 
Commit a27d92b.
On g++ 5.2.1 compile failed with multiply errors:
booredisasync.h:78: error: 'scoped_ptr' in namespace 'boost' does not name a template type
     boost::scoped_ptr<boost::asio::ip::tcp::socket> m_socket;
            ^
booredisasync.cpp:9: error: class 'BooRedisAsync' does not have any field named 'm_socket'
     m_socket(new boost::asio::ip::tcp::socket(*m_ioService)),
     ^
booredisasync.cpp:10: error: class 'BooRedisAsync' does not have any field named 'm_connectTimer'
     m_connectTimer(new boost::asio::deadline_timer(*m_ioService))
     ^

Added include scoped_ptr header for fix this errors.
